### PR TITLE
Update email message

### DIFF
--- a/app/views/thing_mailer/first_adoption_confirmation.html.erb
+++ b/app/views/thing_mailer/first_adoption_confirmation.html.erb
@@ -56,8 +56,7 @@
   <li>
       If your drain is too dirty or hard to clear, you can't find your drain
       (sometimes the maps are incorrect) or there's some other problem with your
-      drain, contact <a href="http://www.sf311.org/index.aspx?page=298">311</a>.
-    # update SF 311 Info website to Savannah
+      drain, contact <a href="https://www.savannahga.gov/FormCenter/311-5/311-Service-Request-Form-36">Savannah 311 City Service Request Form</a>.
   </li>
 </ul>
 

--- a/config/initializers/backport_pg_10_support_to_rails_4.rb
+++ b/config/initializers/backport_pg_10_support_to_rails_4.rb
@@ -1,0 +1,45 @@
+require 'active_record/connection_adapters/postgresql/schema_statements'
+
+#
+# Monkey-patch the refused Rails 4.2 patch at https://github.com/rails/rails/pull    /31330
+#
+# Updates sequence logic to support PostgreSQL 10.
+#
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module SchemaStatements
+        # Resets the sequence of a table's primary key to the maximum value.
+        def reset_pk_sequence!(table, pk = nil, sequence = nil) #:nodoc:
+          unless pk and sequence
+            default_pk, default_sequence = pk_and_sequence_for(table)
+
+            pk ||= default_pk
+            sequence ||= default_sequence
+          end
+
+          if @logger && pk && !sequence
+            @logger.warn "#{table} has primary key #{pk} with no default sequence"
+          end
+
+          if pk && sequence
+            quoted_sequence = quote_table_name(sequence)
+            max_pk = select_value("SELECT MAX(#{quote_column_name pk}) FROM #{quote_table_name(table)}")
+            if max_pk.nil?
+              if postgresql_version >= 100000
+                minvalue = select_value("SELECT seqmin FROM pg_sequence WHERE seqrelid = #{quote(quoted_sequence)}::regclass")
+              else
+                minvalue = select_value("SELECT min_value FROM #{quoted_sequence}")
+              end
+            end
+
+            select_value <<-end_sql, 'SCHEMA'
+              SELECT setval(#{quote(quoted_sequence)}, #{max_pk ? max_pk : minvalue}, #{max_pk ? true : false})
+            end_sql
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/main_controller_test.rb
+++ b/test/controllers/main_controller_test.rb
@@ -12,7 +12,7 @@ class MainControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_select 'title', 'Adopt-a-Drain Savannah'
-    assert_select 'p#tagline', 'Help the city avoid flooding by clearing drains of debris. Click to learn what this means.'
+    assert_select 'p#tagline', 'Prevent storm drain pollution by clearing leaves, dirt, litter, and other debris around city storm drains. Click to learn what this means.'
   end
 
   test 'should show search form when signed in' do

--- a/test/mailers/devise_mailer_test.rb
+++ b/test/mailers/devise_mailer_test.rb
@@ -7,7 +7,7 @@ class DeviseMailerTest < ActionMailer::TestCase
     email = DeviseMailer.reset_password_instructions(@user, '1234').deliver_now
 
     assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal ['no-reply@sfwater.org'], email.from
+    assert_equal ['Info@adopt-a-drain-savannah.org'], email.from
     assert_equal ['erik@example.com'], email.to
     assert_equal 'Adopt-a-drain Savannah reset password instructions', email.subject
   end

--- a/test/mailers/thing_mailer_test.rb
+++ b/test/mailers/thing_mailer_test.rb
@@ -9,7 +9,7 @@ class ThingMailerTest < ActionMailer::TestCase
     email = ThingMailer.first_adoption_confirmation(@thing).deliver_now
 
     assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal ['adoptadraindurham@gmail.com'], email.from
+    assert_equal ['Info@adopt-a-drain-savannah.org'], email.from
     assert_equal ['erik@example.com'], email.to
     assert_equal 'Thanks for adopting a drain, Erik! Here’s important info', email.subject
   end
@@ -22,7 +22,7 @@ class ThingMailerTest < ActionMailer::TestCase
     email = ThingMailer.second_adoption_confirmation(@thing).deliver_now
 
     assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal ['adoptadraindurham@gmail.com'], email.from
+    assert_equal ['Info@adopt-a-drain-savannah.org'], email.from
     assert_equal ['erik@example.com'], email.to
     assert_equal 'Thanks for adopting another drain, Erik!', email.subject
   end
@@ -35,7 +35,7 @@ class ThingMailerTest < ActionMailer::TestCase
     email = ThingMailer.third_adoption_confirmation(@thing).deliver_now
 
     assert_not ActionMailer::Base.deliveries.empty?
-    assert_equal ['adoptadraindurham@gmail.com'], email.from
+    assert_equal ['Info@adopt-a-drain-savannah.org'], email.from
     assert_equal ['erik@example.com'], email.to
     assert_equal 'We really do love you, Erik!', email.subject
   end


### PR DESCRIPTION
Email message update on the first email sent to the user.
backport_pg_10_support_to_rails_4.rb - 
- Is a file that I used to fix an issue found running the test script. 
- This issue appears if you're using postgres 10 or higher. 
- The issue reported: missing increment_by field when selecting the public.users table.
- This issue occurred on MacOS Mojave 10.14.16
- How to reproduce the issue:
 - Prerequisite: User must have postgres 10 or higher installed on the machine.
 1. Open a terminal and CD into the project directory.
 2. Run the following command inside of your terminal: bundle exec rake test
     What you should see a series of failed select statements reporting that the increment_by field is 
     missing.
 